### PR TITLE
fix: wildcard replaced with 'firefox' in apt preferences

### DIFF
--- a/files/mozilla
+++ b/files/mozilla
@@ -1,3 +1,3 @@
-Package: *
+Package: firefox
 Pin: origin packages.mozilla.org
 Pin-Priority: 1000


### PR DESCRIPTION
Fixes package preferences to only Firefox package to mozilla repository