### PR TITLE
feat: remove transitional apt package for snap

### DIFF
--- a/tasks/esr.yml
+++ b/tasks/esr.yml
@@ -4,7 +4,7 @@
 # See more:
 # https://launchpad.net/~mozillateam/+archive/ubuntu/ppa.
 
-- name: Firefox | ESR | Add PPA repository
+- name: "HTH | Firefox | Add ESR PPA repository"
   ansible.builtin.apt_repository:
     repo: ppa:mozillateam/ppa
   when:
@@ -12,7 +12,7 @@
    - firefox.esr is defined
    - firefox.esr
 
-- name: Firefox | ESR | Install package
+- name: "HTH | Firefox | Install ESR package"
   ansible.builtin.apt:
     name: firefox-esr
     state: latest
@@ -21,7 +21,7 @@
     - firefox.esr is defined
     - firefox.esr
 
-- name: Firefox | ESR | Remove package
+- name: "HTH | Firefox | Remove ESR package"
   ansible.builtin.apt:
     name: firefox-esr
     state: absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,19 @@
   when:
     - firefox.gather_facts is not defined or firefox.gather_facts
 
+- name: "HTH | Firefox | Look up installed package version"
+  ansible.builtin.shell:
+    cmd: dpkg-query -W -f='${Version}' firefox 2>/dev/null
+  register: firefox_version
+
+# Note: ansible.builtin.dpkg_selections does not seem to work for
+#       purging the package.
+- name: "HTH | Firefox | Remove snap transition package"
+  ansible.builtin.shell:
+    cmd: dpkg --purge firefox
+  when:
+    - firefox_version.stdout == '1:1snap1-0ubuntu5'
+
 - ansible.builtin.import_tasks: snap.yml
   when:
     - firefox.snap is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: "Firefox | Run assertions"
+- name: "HTH | Firefox | Run assertions"
   ansible.utils.validate:
     data: "{{ firefox }}"
     criteria: "{{ lookup('file', 'assertions/criteria/firefox-criteria.json') | from_json }}"
@@ -8,10 +8,10 @@
   when:
     - firefox is defined
 
-- name: "Firefox | Gather package facts"
+- name: "HTH | Firefox | Gather package facts"
   ansible.builtin.package_facts:
     manager: "auto"
-  when: 
+  when:
     - firefox.gather_facts is not defined or firefox.gather_facts
 
 - ansible.builtin.import_tasks: snap.yml

--- a/tasks/mozilla.yml
+++ b/tasks/mozilla.yml
@@ -4,7 +4,7 @@
 # See more:
 # https://support.mozilla.org/en-US/kb/install-firefox-linux
 
-- name: Firefox | Mozilla | Assure keyrings folder
+- name: "HTH | Firefox | Assure APT keyrings folder"
   ansible.builtin.file:
     path: "/etc/apt/keyrings"
     state: directory
@@ -14,7 +14,7 @@
     modification_time: preserve
     access_time: preserve
 
-- name: Firefox | Mozilla | Add repository signing key
+- name: "HTH | Firefox | Add Mozilla repository signing key"
   ansible.builtin.copy:
     src: "{{ firefox.mozilla.signing.path }}"
     dest: "/etc/apt/keyrings/packages.mozilla.org.asc"
@@ -23,13 +23,13 @@
     group: root
     mode: 0644
 
-- name: Firefox | Mozilla | Add repository to sources
+- name: "HTH | Firefox | Add Mozilla repository to sources"
   ansible.builtin.apt_repository:
     repo: "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main"
     state: present
     filename: mozilla
 
-- name: Firefox | Mozilla | Prioritize repository
+- name: "HTH | Firefox | Prioritize Mozilla repository"
   ansible.builtin.copy:
     src: mozilla
     dest: "/etc/apt/preferences.d/mozilla"
@@ -40,7 +40,7 @@
     - firefox.mozilla.priority is defined
     - firefox.mozilla.priority
 
-- name: Firefox | Mozilla | Install package
+- name: "HTH | Firefox | Install Mozilla package"
   ansible.builtin.apt:
     name: firefox
     state: latest

--- a/tasks/snap.yml
+++ b/tasks/snap.yml
@@ -1,7 +1,7 @@
 # This file contains configuration tasks related to installation of Firefox
 # via Canonical's Snap packages.
 
-- name: Firefox | Snap | Install package
+- name: "HTH | Firefox | Install snap package"
   community.general.snap:
     name: firefox
     state: latest
@@ -9,7 +9,7 @@
     - firefox.snap is defined
     - firefox.snap
 
-- name: Firefox | Snap | Remove package
+- name: "HTH | Firefox | Remove snap package"
   community.general.snap:
     name: firefox
     state: absent


### PR DESCRIPTION
Removes the `1:1snap1-0ubuntu5` package, that ships with Ubuntu 24.04 and causes any attempted installation of package `firefox` via `apt` to install the `snap` package instead. Task naming also standardized.